### PR TITLE
Add AudioCommander privacy policy page

### DIFF
--- a/audiocommander/privacy.html
+++ b/audiocommander/privacy.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>AudioCommander — Privacy Policy | Concatenated</title>
+<meta name="robots" content="index,follow">
+<style>
+  :root { color-scheme: light dark; }
+  body {
+    max-width: 46rem; margin: 0 auto; padding: 2.5rem 1.25rem 4rem;
+    font: 16px/1.65 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    color: #1a1c22; background: #fbfbfc;
+  }
+  @media (prefers-color-scheme: dark) {
+    body { color: #e6e7ea; background: #14161c; }
+    a { color: #7bb0ff; }
+    hr { border-color: #2a2d36; }
+    .lede { color: #b9bcc4; }
+  }
+  h1 { font-size: 1.9rem; margin: 0 0 .25rem; }
+  h2 { font-size: 1.2rem; margin: 2rem 0 .5rem; }
+  .meta { color: #8a8d96; font-size: .9rem; margin: 0 0 1.5rem; }
+  .lede { font-size: 1.05rem; color: #4a4d56; }
+  ul { padding-left: 1.25rem; }
+  li { margin: .3rem 0; }
+  code { font: .9em ui-monospace, SFMono-Regular, Menlo, monospace; }
+  a { color: #1a5fd0; }
+  hr { border: none; border-top: 1px solid #e5e6ea; margin: 2.25rem 0; }
+  footer { color: #8a8d96; font-size: .85rem; margin-top: 2rem; }
+</style>
+</head>
+<body>
+  <h1>AudioCommander — Privacy Policy</h1>
+  <p class="meta">Effective date: August 6, 2026</p>
+
+  <p class="lede">AudioCommander is a browser extension that gives you local control over web audio — per-tab volume, equalization, dynamics, and noise reduction. It <strong>does not collect, transmit, sell, or share any user data.</strong> All audio processing and all settings stay on your device. There are no analytics, no tracking, no accounts, and no external servers.</p>
+
+  <h2>What data is stored</h2>
+  <p>The extension stores the following <strong>locally on your device</strong> (via the browser's extension storage) and never sends it anywhere:</p>
+  <ul>
+    <li>Your settings and preferences (volume levels, EQ bands, compressor/limiter and denoise settings).</li>
+    <li>Saved EQ presets and per-site presets you create.</li>
+    <li>Per-tab and per-domain audio state so your settings persist as you browse.</li>
+  </ul>
+  <p>This data never leaves your browser. Uninstalling the extension removes it.</p>
+
+  <h2>Permissions and why they are used</h2>
+  <ul>
+    <li><strong>tabs</strong> — to identify individual tabs so per-tab volume and per-site presets apply to the correct tab.</li>
+    <li><strong>storage</strong> — to save your settings and presets locally.</li>
+    <li><strong>webNavigation</strong> — to detect when you navigate to a site with a saved preset, so it can be applied automatically.</li>
+    <li><strong>menus</strong> — to provide right-click menu actions for quick audio control.</li>
+    <li><strong>scripting</strong> — to inject the audio-processing content script that adjusts media volume and applies EQ.</li>
+    <li><strong>host access (all sites)</strong> — audio control must work on any site that plays media; the content script attaches to the page's audio graph. It reads no page content beyond what is needed to process audio.</li>
+  </ul>
+
+  <h2>Data collection and sharing</h2>
+  <ul>
+    <li>No personal data is collected.</li>
+    <li>No data is transmitted off your device.</li>
+    <li>No data is sold or shared with third parties.</li>
+    <li>No remote code is loaded or executed; all logic ships inside the extension.</li>
+  </ul>
+
+  <h2>Contact</h2>
+  <p>Questions about this policy: <a href="https://www.concatenated.com">www.concatenated.com</a>, or open an issue on the project's GitHub repository.</p>
+
+  <hr>
+  <footer>AudioCommander is part of the Commander Suite by Concatenated.</footer>
+</body>
+</html>


### PR DESCRIPTION
Adds `audiocommander/privacy.html` so AudioCommander has a public privacy-policy URL for its Chrome Web Store listing.

- Serves at **https://concatenated.com/audiocommander/privacy.html** once merged (static site, served from repo root).
- Self-contained page (inline CSS, light/dark, mobile-friendly). Content: no data collection, all processing local, per-permission rationale.
- No changes to any existing site files.

**To finish:** review the PR preview, merge to `main` (triggers the Azure deploy), then paste that URL into the Chrome Web Store Privacy tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)